### PR TITLE
fix build problems on mac/clang

### DIFF
--- a/tpie/btree/internal_store.h
+++ b/tpie/btree/internal_store.h
@@ -242,10 +242,10 @@ private:
 	size_t m_size;
 
 	template <typename>
-	friend class btree_node;
+	friend class ::tpie::btree_node;
 
 	template <typename>
-	friend class btree_iterator;
+	friend class ::tpie::btree_iterator;
 
 	template <typename, typename>
 	friend class bbits::tree;


### PR DESCRIPTION
@antialize @svendcsvendsen 

This fixes a build problem on Mac(clang). I also checked Linux(g++-4.8), should be fine.

For details/reasons on the issue, see:

http://stackoverflow.com/questions/30418270/clang-bug-namespaced-template-class-friend