### PR TITLE
Don't copy forwarded items

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -155,8 +155,8 @@ add_unittest(pipelining
 	merger_memory
 	bound_fetch_forward
 	fetch_forward
-	forward_minimal_copy
 	forward_multiple_pipelines_test
+	forward_unique_ptr
 	virtual
 	virtual_cref_item_type
 	virtual_fork

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -156,6 +156,7 @@ add_unittest(pipelining
 	bound_fetch_forward
 	fetch_forward
 	forward_minimal_copy
+	forward_multiple_pipelines_test
 	virtual
 	virtual_cref_item_type
 	virtual_fork

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -155,7 +155,7 @@ add_unittest(pipelining
 	merger_memory
 	bound_fetch_forward
 	fetch_forward
-	forward_multiple_pipelines_test
+	forward_multiple_pipelines
 	forward_unique_ptr
 	virtual
 	virtual_cref_item_type

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -155,6 +155,7 @@ add_unittest(pipelining
 	merger_memory
 	bound_fetch_forward
 	fetch_forward
+	forward_minimal_copy
 	virtual
 	virtual_cref_item_type
 	virtual_fork

--- a/test/unit/test_pipelining.cpp
+++ b/test/unit/test_pipelining.cpp
@@ -888,6 +888,16 @@ bool forward_minimal_copy_test() {
 	return true;
 }
 
+bool forward_multiple_pipelines_test() {
+	passive_sorter<int> ps;
+	pipeline p = input_vector(std::vector<int>{3, 2, 1}) | ps.input();
+	p.forward("test", 8);
+	pipeline p_ = input_vector(std::vector<int>{5, 6, 7}) | add_pairs(ps.output()) | null_sink<int>();
+	p();
+	int val = p_.fetch<int>("test");
+	return val == 8;
+}
+
 // Assume that dest_t::item_type is a reference type.
 // Push a dereferenced zero pointer to the destination.
 template <typename dest_t>
@@ -2137,6 +2147,7 @@ int main(int argc, char ** argv) {
 	.test(fetch_forward_test, "fetch_forward")
 	.test(bound_fetch_forward_test, "bound_fetch_forward")
 	.test(forward_minimal_copy_test, "forward_minimal_copy")
+	.test(forward_multiple_pipelines_test, "forward_multiple_pipelines")
 	.test(virtual_test, "virtual")
 	.test(virtual_fork_test, "virtual_fork")
 	.test(virtual_cref_item_type_test, "virtual_cref_item_type")

--- a/test/unit/test_pipelining.cpp
+++ b/test/unit/test_pipelining.cpp
@@ -858,9 +858,10 @@ struct FUP2 : public node {
 
 bool forward_unique_ptr_test() {
 	std::unique_ptr<int> ptr(new int(1337));
-	pipeline p = input_vector(std::vector<int>()) | null_sink<int>();
+	pipeline p = make_pipe_begin<FUP1>()
+		| make_pipe_end<FUP2>();
 	p.plot(log_info());
-	p.forward("ptr", ptr);
+	p.forward("ptr", std::move(ptr));
 	p();
 	if (!forward_unique_ptr_result) return false;
 	if (!p.can_fetch("ptr")) {

--- a/tpie/pipelining/container.h
+++ b/tpie/pipelining/container.h
@@ -193,6 +193,12 @@ public:
 	friend T & any_cast(any_noncopyable & a);
 	
 	friend void swap(any_noncopyable & l, any_noncopyable & r);
+
+	const std::type_info & type() const {
+		if (!cont) return typeid(void);
+		auto val = cont.get();
+		return typeid(*val);
+	}
 private:
 	std::unique_ptr<bits::any_noncopyable_cont_base> cont;
 };

--- a/tpie/pipelining/container.h
+++ b/tpie/pipelining/container.h
@@ -145,6 +145,9 @@ namespace bits {
 class any_noncopyable_cont_base {
 public:
 	virtual ~any_noncopyable_cont_base() {};
+	virtual const std::type_info & type() const {
+		return typeid(void);
+	}
 };
 
 template <typename T>
@@ -152,6 +155,9 @@ class any_noncopyable_cont: public any_noncopyable_cont_base {
 public:
 	any_noncopyable_cont(T value): value(move_if_movable<T>(value)) {}
 	T value;
+	const std::type_info & type() const override {
+		return typeid(value);
+	}
 };
 
 } //namespace bits
@@ -197,7 +203,7 @@ public:
 	const std::type_info & type() const {
 		if (!cont) return typeid(void);
 		auto val = cont.get();
-		return typeid(*val);
+		return val->type();
 	}
 private:
 	std::unique_ptr<bits::any_noncopyable_cont_base> cont;

--- a/tpie/pipelining/node.cpp
+++ b/tpie/pipelining/node.cpp
@@ -227,7 +227,7 @@ void node::add_forwarded_data(std::string key, node_token::id_t from_node) {
 }
 
 node::maybeany_t node::fetch_maybe(std::string key) {
-	bits::node_map::ptr nodeMap = get_node_map()->find_authority();
+	auto nodeMap = get_node_map()->find_authority();
 
 	auto it = m_forwardedToHere.find(key);
 	if (it == m_forwardedToHere.end()) {
@@ -235,7 +235,7 @@ node::maybeany_t node::fetch_maybe(std::string key) {
 		return nodeMap->fetch_maybe(key);
 	}
 
-	node_token::id_t fetch_from_id = it->second;
+	auto fetch_from_id = it->second;
 	node *fetch_from = nodeMap->get(fetch_from_id);
 	if (!fetch_from) {
 		return maybeany_t();

--- a/tpie/pipelining/node.cpp
+++ b/tpie/pipelining/node.cpp
@@ -187,7 +187,7 @@ void node::_internal_set_available_of_resource(resource_type type, memory_size_t
 	}
 }
 
-void node::forward_any(std::string key, any_noncopyable && value, memory_size_type k) {
+void node::forward_any(std::string key, any_noncopyable value, memory_size_type k) {
 	switch (get_state()) {
 		case STATE_FRESH:
 		case STATE_IN_PREPARE:

--- a/tpie/pipelining/node.cpp
+++ b/tpie/pipelining/node.cpp
@@ -244,12 +244,11 @@ node::maybeany_t node::fetch_maybe(std::string key) {
 	return fetch_from->get_forwarded_data_maybe(key);
 }
 
-any_noncopyable & node::fetch_any(std::string key, const std::string & type_name) {
+any_noncopyable & node::fetch_any(std::string key) {
 	maybeany_t value = fetch_maybe(key);
 	if (!value) {
 		std::stringstream ss;
-		ss << "Tried to fetch nonexistent key '" << key
-		   << "' of type " << type_name
+		ss << "Tried to fetch nonexistent key '" << key << "'" 
 		   << " in " << get_name() << " of type " << typeid(*this).name();
 		throw invalid_argument_exception(ss.str());
 	}

--- a/tpie/pipelining/node.h
+++ b/tpie/pipelining/node.h
@@ -608,7 +608,7 @@ public:
 	/// \brief Fetch piece of auxiliary data, expecting a given value type.
 	///////////////////////////////////////////////////////////////////////////
 	template <typename T>
-	inline T fetch(std::string key) {
+	inline T & fetch(std::string key) {
 		any_noncopyable &item = fetch_any(key, typeid(T).name());
 		try {
 			return any_cast<T>(item);

--- a/tpie/pipelining/node.h
+++ b/tpie/pipelining/node.h
@@ -602,14 +602,14 @@ public:
 	/// \brief Fetch piece of auxiliary data as any_noncopyable (the internal
 	/// representation).
 	///////////////////////////////////////////////////////////////////////////
-	any_noncopyable & fetch_any(std::string key, const std::string & type_name = "any_noncopyable");
+	any_noncopyable & fetch_any(std::string key);
 
 	///////////////////////////////////////////////////////////////////////////
 	/// \brief Fetch piece of auxiliary data, expecting a given value type.
 	///////////////////////////////////////////////////////////////////////////
 	template <typename T>
 	inline T & fetch(std::string key) {
-		any_noncopyable &item = fetch_any(key, typeid(T).name());
+		any_noncopyable &item = fetch_any(key);
 		try {
 			return any_cast<T>(item);
 		} catch (bad_any_noncopyable_cast m) {

--- a/tpie/pipelining/node.h
+++ b/tpie/pipelining/node.h
@@ -563,13 +563,13 @@ public:
 	///////////////////////////////////////////////////////////////////////////
 	template <typename T>
 	void forward(std::string key, T value, memory_size_type k = std::numeric_limits<memory_size_type>::max()) {
-		forward_any(key, any_noncopyable(value), k);
+		forward_any(key, any_noncopyable(std::move(value)), k);
 	}
 
 	///////////////////////////////////////////////////////////////////////////
 	/// \brief See \ref node::forward.
 	///////////////////////////////////////////////////////////////////////////
-	void forward_any(std::string key, any_noncopyable && value, memory_size_type k = std::numeric_limits<memory_size_type>::max());
+	void forward_any(std::string key, any_noncopyable value, memory_size_type k = std::numeric_limits<memory_size_type>::max());
 
 private:
 	///////////////////////////////////////////////////////////////////////////

--- a/tpie/pipelining/node.h
+++ b/tpie/pipelining/node.h
@@ -24,7 +24,6 @@
 #include <tpie/pipelining/tokens.h>
 #include <tpie/progress_indicator_base.h>
 #include <tpie/progress_indicator_null.h>
-#include <boost/any.hpp>
 #include <tpie/pipelining/priority_type.h>
 #include <tpie/pipelining/predeclare.h>
 #include <tpie/pipelining/node_name.h>
@@ -78,6 +77,8 @@ struct node_parameters {
 ///////////////////////////////////////////////////////////////////////////////
 class node {
 public:
+	typedef boost::optional<any_noncopyable &> maybeany_t;
+
 	///////////////////////////////////////////////////////////////////////////
 	/// \brief  Options for how to plot this node
 	//////////////////////////////////////////////////////////////////////////
@@ -562,13 +563,13 @@ public:
 	///////////////////////////////////////////////////////////////////////////
 	template <typename T>
 	void forward(std::string key, T value, memory_size_type k = std::numeric_limits<memory_size_type>::max()) {
-		forward_any(key, boost::any(value), k);
+		forward_any(key, any_noncopyable(value), k);
 	}
 
 	///////////////////////////////////////////////////////////////////////////
 	/// \brief See \ref node::forward.
 	///////////////////////////////////////////////////////////////////////////
-	void forward_any(std::string key, boost::any value, memory_size_type k = std::numeric_limits<memory_size_type>::max());
+	void forward_any(std::string key, any_noncopyable && value, memory_size_type k = std::numeric_limits<memory_size_type>::max());
 
 private:
 	///////////////////////////////////////////////////////////////////////////
@@ -579,32 +580,39 @@ private:
 	///////////////////////////////////////////////////////////////////////////
 	/// \brief Called by fetch_any to get data forwarded from this node.
 	///////////////////////////////////////////////////////////////////////////
-	boost::any get_forwarded_data(std::string key, const std::string & type_name = "boost::any");
+	maybeany_t get_forwarded_data_maybe(std::string key);
 
 public:
 	///////////////////////////////////////////////////////////////////////////
 	/// \brief Find out if there is a piece of auxiliary data forwarded with a
 	/// given name.
 	///////////////////////////////////////////////////////////////////////////
-	inline bool can_fetch(std::string key) {
-		return m_forwardedToHere.count(key) != 0;
+	bool can_fetch(std::string key) {
+		return bool(fetch_maybe(key));
 	}
 
 	///////////////////////////////////////////////////////////////////////////
-	/// \brief Fetch piece of auxiliary data as boost::any (the internal
+	/// \brief Fetch piece of auxiliary data as any_noncopyable (the internal
+	/// representation) wrapped in a boost::optional which is unitialized
+	/// if the key is not found.
+	///////////////////////////////////////////////////////////////////////////
+	maybeany_t fetch_maybe(std::string key);
+
+	///////////////////////////////////////////////////////////////////////////
+	/// \brief Fetch piece of auxiliary data as any_noncopyable (the internal
 	/// representation).
 	///////////////////////////////////////////////////////////////////////////
-	boost::any fetch_any(std::string key, const std::string & type_name = "boost::any");
+	any_noncopyable & fetch_any(std::string key, const std::string & type_name = "any_noncopyable");
 
 	///////////////////////////////////////////////////////////////////////////
 	/// \brief Fetch piece of auxiliary data, expecting a given value type.
 	///////////////////////////////////////////////////////////////////////////
 	template <typename T>
 	inline T fetch(std::string key) {
-		boost::any item = fetch_any(key, typeid(T).name());
+		any_noncopyable &item = fetch_any(key, typeid(T).name());
 		try {
-			return boost::any_cast<T>(item);
-		} catch (boost::bad_any_cast m) {
+			return any_cast<T>(item);
+		} catch (bad_any_noncopyable_cast m) {
 			std::stringstream ss;
 			ss << "Trying to fetch key '" << key << "' of type "
 			   << typeid(T).name() << " but forwarded data was of type "
@@ -805,7 +813,7 @@ private:
 	node_parameters m_parameters;
 	std::vector<std::unique_ptr<memory_bucket> > m_buckets;
 	
-	std::map<std::string, boost::any> m_forwardedFromHere;
+	std::map<std::string, any_noncopyable> m_forwardedFromHere;
 	std::map<std::string, node_token::id_t> m_forwardedToHere;
 
 	datastructuremap_t m_datastructures;

--- a/tpie/pipelining/pipeline.cpp
+++ b/tpie/pipelining/pipeline.cpp
@@ -144,7 +144,7 @@ void pipeline_base::operator()(stream_size_type items, progress_indicator_base &
 	*/
 }
 
-void pipeline_base_base::forward_any(std::string key, any_noncopyable && value) {
+void pipeline_base_base::forward_any(std::string key, any_noncopyable value) {
 	get_node_map()->find_authority()->forward(key, std::move(value));
 }
 

--- a/tpie/pipelining/pipeline.cpp
+++ b/tpie/pipelining/pipeline.cpp
@@ -144,14 +144,8 @@ void pipeline_base::operator()(stream_size_type items, progress_indicator_base &
 	*/
 }
 
-void pipeline_base_base::forward_any(std::string key, const boost::any & value) {
-	node_map::ptr map = m_nodeMap->find_authority();
-	runtime rt(map);
-	std::vector<node *> sources;
-	rt.get_item_sources(sources);
-	for (size_t j = 0; j < sources.size(); ++j) {
-		sources[j]->forward_any(key, value);
-	}
+void pipeline_base_base::forward_any(std::string key, any_noncopyable && value) {
+	get_node_map()->find_authority()->forward(key, std::move(value));
 }
 
 bool pipeline_base_base::can_fetch(std::string key) {
@@ -165,7 +159,7 @@ bool pipeline_base_base::can_fetch(std::string key) {
 	return false;
 }
 
-boost::any pipeline_base_base::fetch_any(std::string key) {
+any_noncopyable & pipeline_base_base::fetch_any(std::string key) {
 	node_map::ptr map = m_nodeMap->find_authority();
 	runtime rt(map);
 	std::vector<node *> sinks;

--- a/tpie/pipelining/pipeline.h
+++ b/tpie/pipelining/pipeline.h
@@ -251,8 +251,8 @@ public:
 	}
 
 	template <typename T>
-	void forward(std::string key, T value) {
-		forward_any(key, any_noncopyable(value));
+	void forward(std::string key, T && value) {
+		forward_any(key, any_noncopyable(std::move(value)));
 	}
 
 	pipeline & then(pipeline & other) {

--- a/tpie/pipelining/pipeline.h
+++ b/tpie/pipelining/pipeline.h
@@ -241,7 +241,7 @@ public:
 	}
 
 	template <typename T>
-	T fetch(std::string key) {
+	T & fetch(std::string key) {
 		any_noncopyable &a = fetch_any(key);
 		return any_cast<T>(a);
 	}

--- a/tpie/pipelining/pipeline.h
+++ b/tpie/pipelining/pipeline.h
@@ -72,7 +72,7 @@ public:
 	///////////////////////////////////////////////////////////////////////////
 	virtual ~pipeline_base_base() {}
 
-	void forward_any(std::string key, any_noncopyable && value);
+	void forward_any(std::string key, any_noncopyable value);
 	
 	bool can_fetch(std::string key);
 
@@ -246,12 +246,12 @@ public:
 		return any_cast<T>(a);
 	}
 
-	void forward_any(std::string key, any_noncopyable && value) {
+	void forward_any(std::string key, any_noncopyable value) {
 		p->forward_any(key, std::move(value));
 	}
 
 	template <typename T>
-	void forward(std::string key, T && value) {
+	void forward(std::string key, T value) {
 		forward_any(key, any_noncopyable(std::move(value)));
 	}
 

--- a/tpie/pipelining/pipeline.h
+++ b/tpie/pipelining/pipeline.h
@@ -20,7 +20,6 @@
 #ifndef __TPIE_PIPELINING_PIPELINE_H__
 #define __TPIE_PIPELINING_PIPELINE_H__
 
-#include <boost/any.hpp>
 #include <tpie/types.h>
 #include <iostream>
 #include <tpie/pipelining/tokens.h>
@@ -73,11 +72,11 @@ public:
 	///////////////////////////////////////////////////////////////////////////
 	virtual ~pipeline_base_base() {}
 
-	void forward_any(std::string key, const boost::any & value);
+	void forward_any(std::string key, any_noncopyable && value);
 	
 	bool can_fetch(std::string key);
 
-	boost::any fetch_any(std::string key);
+	any_noncopyable & fetch_any(std::string key);
 
 	node_map::ptr get_node_map() const {
 		return m_nodeMap;
@@ -237,23 +236,23 @@ public:
 		return p->can_fetch(key);
 	}
 
-	boost::any fetch_any(std::string key) {
+	any_noncopyable & fetch_any(std::string key) {
 		return p->fetch_any(key);
 	}
 
 	template <typename T>
 	T fetch(std::string key) {
-		boost::any a = fetch_any(key);
-		return *boost::any_cast<T>(&a);
+		any_noncopyable &a = fetch_any(key);
+		return any_cast<T>(a);
 	}
 
-	void forward_any(std::string key, const boost::any & value) {
-		return p->forward_any(key, value);
+	void forward_any(std::string key, any_noncopyable && value) {
+		p->forward_any(key, std::move(value));
 	}
 
 	template <typename T>
 	void forward(std::string key, T value) {
-		forward_any(key, boost::any(value));
+		forward_any(key, any_noncopyable(value));
 	}
 
 	pipeline & then(pipeline & other) {

--- a/tpie/pipelining/subpipeline.h
+++ b/tpie/pipelining/subpipeline.h
@@ -137,23 +137,23 @@ struct subpipeline {
 		return p->can_fetch(key);
 	}
 
-	boost::any fetch_any(std::string key) {
+	any_noncopyable fetch_any(std::string key) {
 		return p->fetch_any(key);
 	}
 
 	template <typename T>
 	T fetch(std::string key) {
-		boost::any a = fetch_any(key);
-		return *boost::any_cast<T>(&a);
+		any_noncopyable a = fetch_any(key);
+		return *any_cast<T>(&a);
 	}
 
-	void forward_any(std::string key, const boost::any & value) {
+	void forward_any(std::string key, const any_noncopyable & value) {
 		return p->forward_any(key, value);
 	}
 
 	template <typename T>
 	void forward(std::string key, T value) {
-		forward_any(key, boost::any(value));
+		forward_any(key, any_noncopyable(value));
 	}
 
 	void output_memory(std::ostream & o) const {p->output_memory(o);}

--- a/tpie/pipelining/tokens.cpp
+++ b/tpie/pipelining/tokens.cpp
@@ -50,6 +50,9 @@ void node_map::link(node_map::ptr target) {
 	for (relmapit i = target->m_relationsInv.begin(); i != target->m_relationsInv.end(); ++i) {
 		m_relationsInv.insert(*i);
 	}
+	for (auto i = target->m_pipelineForwards.begin(); i != m_pipelineForwards.end(); ++i) {
+		m_pipelineForwards[i->first] = std::move(i->second);
+	}
 	target->m_tokens.clear();
 	target->m_authority = this;
 

--- a/tpie/pipelining/tokens.h
+++ b/tpie/pipelining/tokens.h
@@ -197,7 +197,7 @@ public:
 	///////////////////////////////////////////////////////////////////////////
 	void get_successors(id_t from, std::vector<id_t> & successors, memory_size_type k, bool forward_only=false);
 
-	void forward(std::string key, any_noncopyable && value) {
+	void forward(std::string key, any_noncopyable value) {
 		m_pipelineForwards[key] = std::move(value);
 	}
 

--- a/tpie/pipelining/tokens.h
+++ b/tpie/pipelining/tokens.h
@@ -81,6 +81,7 @@
 #include <vector>
 #include <iostream>
 #include <boost/intrusive_ptr.hpp>
+#include <boost/optional.hpp>
 #include <unordered_map>
 
 namespace tpie {
@@ -109,6 +110,9 @@ public:
 	typedef relmap_t::const_iterator relmapit;
 
 	typedef std::unordered_map<std::string, std::pair<memory_size_type, any_noncopyable> > datastructuremap_t;
+
+	typedef boost::optional<any_noncopyable &> maybeany_t;
+	typedef std::unordered_map<std::string, any_noncopyable> forwardmap_t;
 
 	typedef boost::intrusive_ptr<node_map> ptr;
 
@@ -193,6 +197,17 @@ public:
 	///////////////////////////////////////////////////////////////////////////
 	void get_successors(id_t from, std::vector<id_t> & successors, memory_size_type k, bool forward_only=false);
 
+	void forward(std::string key, any_noncopyable && value) {
+		m_pipelineForwards[key] = std::move(value);
+	}
+
+	maybeany_t fetch_maybe(std::string key) {
+		auto it = m_pipelineForwards.find(key);
+		if (it == m_pipelineForwards.end()) {
+			return maybeany_t();
+		}
+		return maybeany_t(it->second);
+	}
 
 	friend void intrusive_ptr_add_ref(node_map * m) {
 		m->m_refCnt++;
@@ -208,6 +223,7 @@ private:
 	relmap_t m_relations;
 	relmap_t m_relationsInv;
 	datastructuremap_t m_datastructures;
+	forwardmap_t m_pipelineForwards;
 
 	size_t out_degree(const relmap_t & map, id_t from, node_relation rel) const;
 	size_t out_degree(const relmap_t & map, id_t from) const;


### PR DESCRIPTION
Instead we store the items forwarded from nodes in that node and forward the node token of that node, which we can use to fetch the item with.
When forwarding from a pipeline, we now store that in the nodemap and fetch on nodes has been modified to also look for a key there.

As a result of this, you can now forward and fetch `unique_ptr`'s.
