### PR TITLE
Throw when closing a file results in an error.

### DIFF
--- a/tpie/file_accessor/posix.inl
+++ b/tpie/file_accessor/posix.inl
@@ -146,6 +146,7 @@ void posix::close_i() {
 	if (m_fd == 0) return;
 	if (::close(m_fd) == -1) throw_errno();
 	get_file_manager().decrement_open_file_count();
+	m_fd = 0;
 }
 
 void posix::truncate_i(stream_size_type bytes) {

--- a/tpie/file_accessor/posix.inl
+++ b/tpie/file_accessor/posix.inl
@@ -40,7 +40,7 @@ void posix::throw_errno(std::string path /*=std::string()*/) {
 }
 
 posix::posix()
-	: m_fd(0)
+	: m_fd(-1)
 	, m_cacheHint(access_normal)
 {
 }
@@ -139,14 +139,14 @@ void posix::open_rw_new(const std::string & path) {
 }
 
 bool posix::is_open() const {
-	return m_fd != 0;
+	return m_fd != -1;
 }
 
 void posix::close_i() {
-	if (m_fd == 0) return;
+	if (m_fd == -1) return;
 	if (::close(m_fd) == -1) throw_errno();
 	get_file_manager().decrement_open_file_count();
-	m_fd = 0;
+	m_fd = -1;
 }
 
 void posix::truncate_i(stream_size_type bytes) {

--- a/tpie/file_accessor/posix.inl
+++ b/tpie/file_accessor/posix.inl
@@ -143,12 +143,9 @@ bool posix::is_open() const {
 }
 
 void posix::close_i() {
-	if (m_fd != 0) {
-		if (::close(m_fd) == 0) {
-			get_file_manager().decrement_open_file_count();
-		}
-	}
-	m_fd=0;
+	if (m_fd == 0) return;
+	if (::close(m_fd) == -1) throw_errno();
+	get_file_manager().decrement_open_file_count();
 }
 
 void posix::truncate_i(stream_size_type bytes) {

--- a/tpie/file_accessor/stdio.inl
+++ b/tpie/file_accessor/stdio.inl
@@ -103,11 +103,10 @@ void stdio::open(const std::string & path,
 }
 
 void stdio::close() {
-	if (m_fd && m_write) write_header(true);
-	if (m_fd != 0) {
-		::fclose(m_fd);
-		get_file_manager().decrement_open_file_count();
-	}
+	if (m_fd == 0) return;
+	if (m_write) write_header(true);
+	if (::fclose(m_fd) != 0) throw_errno();
+	get_file_manager().decrement_open_file_count();
 	m_fd=0;
 }
 

--- a/tpie/file_accessor/win32.inl
+++ b/tpie/file_accessor/win32.inl
@@ -124,11 +124,9 @@ bool win32::is_open() const {
 }
 
 void win32::close_i() {
-	if (m_fd != INVALID_HANDLE_VALUE) {
-		if(CloseHandle(m_fd)) {
-			get_file_manager().decrement_open_file_count();
-		}
-	}
+	if (m_fd == INVALID_HANDLE_VALUE) return;
+	if (!CloseHandle(m_fd)) throw_getlasterror();
+	get_file_manager().decrement_open_file_count();
 	m_fd=INVALID_HANDLE_VALUE;
 }
 


### PR DESCRIPTION
According to the close(2) man page, `close()` may return -1 in case, for example, buffers can't be written to disk.  I think this should be handled the same as when write() returns -1.