### PR TITLE
Add tpie::priority_queue(mm_avail) to documentation

### DIFF
--- a/tpie/priority_queue.h
+++ b/tpie/priority_queue.h
@@ -89,11 +89,9 @@ public:
 	///////////////////////////////////////////////////////////////////////////
 	priority_queue(double f=1.0, float b=default_blocksize, stream_size_type n = std::numeric_limits<stream_size_type>::max());
 
-#ifndef DOXYGEN
 	// \param mmavail Number of bytes the priority queue is allowed to use.
 	// \param b Block factor
 	priority_queue(memory_size_type mm_avail, float b=default_blocksize, stream_size_type n = std::numeric_limits<stream_size_type>::max());
-#endif
 
 	/////////////////////////////////////////////////////////
     ///


### PR DESCRIPTION
Closes #244 , assuming it is not a bad thing to add this to the documentation.