### PR TITLE
Set tests to OFF if TPIE is in a submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,13 @@
 # doc/CMakeLists.txt uses configure_file behavior from CMake 2.8
 cmake_minimum_required(VERSION 3.1)
 
-project(tpie)
+if(DEFINED PROJECT_NAME)
+  set(MAIN_PROJECT OFF)
+else()
+  set(MAIN_PROJECT ON)
+endif()
 
+project(tpie)
 
 #### CONFIG.H Checks:
 include(CheckIncludeFiles)
@@ -104,7 +109,7 @@ add_subdirectory(tpie)
 
 add_subdirectory(doc)
 
-option(COMPILE_TEST "Compile test programs" ON)
+option(COMPILE_TEST "Compile test programs" ${MAIN_PROJECT})
 option(TPL_LOGGING "Enable tpie logging." ON)
 option(TPIE_DEPRECATED_WARNINGS "Enable warnings for deprecated classes, methods and typedefs" OFF)
 option(TPIE_PARALLEL_SORT "Enable parallel quick sort implementation" ON)


### PR DESCRIPTION
One could argue both ways: when you just run `make` on a project with TPIE as its dependency should tests be compiled and run for TPIE too or should you trust your TPIE dependency just to work? I'd advocate for the latter (primarily to not having to wait so long).

Of course, in most cases I specify what target I want to create, but when I want to run `make && make install` on my project, I would not want to wait for all TPIE's unit tests to compile.