### PR TITLE
merge_sorter_base::calculate_parameters(): since b0a0bfcab6cb91cfbca0…

### DIFF
--- a/tpie/pipelining/merge_sorter.cpp
+++ b/tpie/pipelining/merge_sorter.cpp
@@ -322,7 +322,7 @@ void merge_sorter_base::calculate_parameters() {
 	memory_size_type tempFileMemory = 2*p.fanout*sizeof(temp_file);
 	
 	log_pipe_debug() << "Phase 1: " << p.memoryPhase1 << " b available memory; " << streamMemory << " b for a single stream; " << tempFileMemory << " b for temp_files\n";
-	memory_size_type min_m1 = 128*1024 / m_item_size + bits::run_positions::memory_usage() + streamMemory + tempFileMemory;
+	memory_size_type min_m1 = std::max(128*1024UL, 16*m_item_size) + bits::run_positions::memory_usage() + streamMemory + tempFileMemory;
 	if (p.memoryPhase1 < min_m1) {
 		log_warning() << "Not enough phase 1 memory for 128 KB items and an open stream! (" << p.memoryPhase1 << " < " << min_m1 << ")\n";
 		p.memoryPhase1 = min_m1;


### PR DESCRIPTION
…f37df208f8f7167cf8bb minimum memory computation was broken.  We're not sure where the 128 KB comes from, but now the minimum memory is set so there's space for (128KB / item_size) items or 16 items, whichever is larger.