### PR TITLE
Update deprecated 'std::uncaught_exception' to its C++17 equivalent

### DIFF
--- a/tpie/fractional_progress.cpp
+++ b/tpie/fractional_progress.cpp
@@ -258,7 +258,7 @@ void fractional_subindicator::done() {
 
 fractional_subindicator::~fractional_subindicator() {
 #ifndef TPIE_NDEBUG
-	if (!m_init_called && m_fraction > 0.00001 && !std::uncaught_exception()) {
+	if (!m_init_called && m_fraction > 0.00001 && !std::uncaught_exceptions()) {
 		std::stringstream s;
 		if (!m_stat.empty()) {
 			s << "A fractional_subindicator for ``" << m_stat << "'' was assigned a non-zero fraction but never initialized." << std::endl;
@@ -323,7 +323,7 @@ void fractional_progress::done() {
 
 fractional_progress::~fractional_progress() {
 #ifndef TPIE_NDEBUG
-	if (m_init_called && !m_done_called && !std::uncaught_exception()) {
+	if (m_init_called && !m_done_called && !std::uncaught_exceptions()) {
 		std::stringstream s;
 		s << "A fractional_progress was destructed without done being called." << std::endl;
 		TP_LOG_FATAL(s.str());

--- a/tpie/progress_indicator_subindicator.cpp
+++ b/tpie/progress_indicator_subindicator.cpp
@@ -116,7 +116,7 @@ void progress_indicator_subindicator::setup(progress_indicator_base * parent,
 
 #ifndef TPIE_NDEBUG
 progress_indicator_subindicator::~progress_indicator_subindicator() {
-	if (m_init_called && !m_done_called && !std::uncaught_exception()) {
+	if (m_init_called && !m_done_called && !std::uncaught_exceptions()) {
 		std::stringstream s;
 		s << "A progress_indicator_subindicator was destructed without done being called." << std::endl;
 		TP_LOG_FATAL(s.str());


### PR DESCRIPTION
Removes the deprecation warnings I get while compiling TPIE ( on top of the ones I get in #257 ).