### PR TITLE
Fix link to GitHub pages being relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ branch is very stable and is unlikely to see major breaking changes.
 For help, installation, usage and documentation, visit the
 [TPIE homepage](http://www.madalgo.au.dk/tpie/); the API documentation is also
 hosted [there](http://www.madalgo.au.dk/tpie/doc/) and on
-[GitHub pages](thomasmoelhave.github.io/tpie).
+[GitHub pages](http://www.thomasmoelhave.github.io/tpie).
 
 ## Dependencies
 


### PR DESCRIPTION
This of course still requires that the newest version of the documentation in the *gh-pages* branch actually is turned on in the repository's settings (takes one or two minutes to do).