### PR TITLE
Fix Clang-14 error: 'expression result unused'

### DIFF
--- a/tpie/memory.cpp
+++ b/tpie/memory.cpp
@@ -169,7 +169,7 @@ std::unordered_map<std::type_index, memory_digest_item> memory_manager::memory_d
 #endif
 		mdi.count = p.second.count;
 		mdi.bytes = p.second.bytes;
-		res.emplace(p.first, std::move(mdi)).first;
+		res.emplace(p.first, std::move(mdi));
 	}
 	return res;
 }


### PR DESCRIPTION
I stumbled over this warning of an unused result (and hence over-complicated code) trying to set up cross-platform support CI on my dependent project.